### PR TITLE
自动将 【 转为 [

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1018,23 +1018,21 @@ export default class EasyTypingPlugin extends Plugin {
 
         if(editor.somethingSelected() && this.settings.SelectedFormat)
         {
-            // console.log('symbol:', symbol);
-            if(symbol === '￥')
-            {
-                symbol = '$';
-            }
-            else if(symbol === '·')
-            {
-                symbol = '`';
-            }
-            else{
-                return;
-            }
+						// console.log('symbol:', symbol);
+						if (symbol === "￥") {
+								symbol = "$$";
+						} else if (symbol === "·") {
+								symbol = "``";
+						} else if (symbol === "【") {
+								symbol = "[]";
+						} else {
+								return;
+						}
 
-            const selected = editor.getSelection();
-            const replaceText = symbol+selected+symbol;
-            // @ts-ignore
-            obj.update(null, null, [replaceText]);
+						const selected = editor.getSelection();
+						const replaceText = symbol.charAt(0) + selected + symbol.charAt(1);
+						// @ts-ignore
+						obj.update(null, null, [replaceText]);
         }
     }
 
@@ -1378,8 +1376,8 @@ class EasyTypingSettingTab extends PluginSettingTab {
 		});
 
         new Setting(containerEl)
-		.setName("When something selected, `￥` will format the selected text to inline formula\n`·` will format the selected text to inline code")
-		.setDesc("选中文本情况下，按中文的￥键，将自动替换成$，变成行内公式\n按中文的·，将自动替换成`，变成行内代码块")
+		.setName("When something selected, `￥` will format the selected text to inline formula; `·` will format the selected text to inline code; `【` will format the selected text to link")
+                .setDesc("选中文本情况下，按中文的￥键，将自动替换成$，变成行内公式；按中文的·，将自动替换成`，变成行内代码块；按中文的【，将自动替换成[，变成链接块。")
 		.addToggle((toggle)=>{
 			toggle.setValue(this.plugin.settings.SelectedFormat).onChange(async (value)=>{
 				this.plugin.settings.SelectedFormat = value;


### PR DESCRIPTION
输入双链的时候，在有选择状况下中文`【`不会自动转为`[`，所以参考`￥·`部分的代码提了这个 PR。
但是理想情况是输入一次`[]`后，光标仍然处于框选状态，而不是在`]`后边。目前只修改了`beforechange`部分的代码（和配置区），感觉如果要对 `Cursor` 处理的话可能需要设置一个全局变量再去 [`setSelection`](https://github.com/obsidianmd/obsidian-api/blob/master/obsidian.d.ts#L728)，因为对整体代码并不清楚所以先没有做到这一步的改动。