### PR TITLE
更新设置页的文档链接和教程链接

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -419,7 +419,7 @@ export class EasyTypingSettingTab extends PluginSettingTab {
 
 		containerEl.createEl("p", { text: locale.headers.aboutRegexp.header }).createEl("a", {
 			text: locale.headers.aboutRegexp.text,
-			href: "https://javascript.ruanyifeng.com/stdlib/regexp.html#",
+			href: "https://wangdoc.com/javascript/stdlib/regexp",
 		});
 
 		containerEl.createEl("p", { text: locale.headers.instructionsRegexp.header }).createEl("a", {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -424,7 +424,7 @@ export class EasyTypingSettingTab extends PluginSettingTab {
 
 		containerEl.createEl("p", { text: locale.headers.instructionsRegexp.header }).createEl("a", {
 			text: locale.headers.instructionsRegexp.text,
-			href: "https://github.com/Yaozhuwa/easy-typing-obsidian/blob/master/UserDefinedRegExp.md",
+			href: "https://github.com/Yaozhuwa/easy-typing-obsidian/blob/master/Doc/UserDefinedRegExp.md",
 		});
 
 		const regContentAreaSetting = new Setting(containerEl);


### PR DESCRIPTION
1. 更新失效的「自定义正则表达式规则」文档链接。
2. 将「《阮一峰：正则表达式简明教程》」的链接，更新为搬迁后的新网址。

<img width="1900" height="649" alt="图片" src="https://github.com/user-attachments/assets/ffa12535-cfd5-43c3-96f5-06b2129f99b3" />